### PR TITLE
Raise an exception if the cacher can't clone a git repository

### DIFF
--- a/alma_tests_cacher/cacher.py
+++ b/alma_tests_cacher/cacher.py
@@ -177,7 +177,11 @@ class AlmaTestsCacher:
             repo_dir = Path(workdir, repo_dirname)
             if not repo_dir.exists():
                 self.logger.info('Start cloning git repo: %s', repo.url)
-                exit_code, stdout, stderr = clone_git_repo(workdir, repo.url)
+                try:
+                    exit_code, stdout, stderr = clone_git_repo(workdir, repo.url)
+                except Exception:
+                    self.logger.exception('Cannot clone git repo:')
+                    return
                 self.logger.debug(
                     'Clone result:\nexit_code: %s\nstdout: %s\nstderr: %s',
                     exit_code,

--- a/alma_tests_cacher/utils.py
+++ b/alma_tests_cacher/utils.py
@@ -35,7 +35,6 @@ def clone_git_repo(
         .with_cwd(workdir_path)
         .run(
             ['clone', repo_url],
-            retcode=None,
         )
     )
 

--- a/tests/test_cacher.py
+++ b/tests/test_cacher.py
@@ -116,11 +116,30 @@ def mock_bulk_create(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
     monkeypatch.setattr(AlmaTestsCacher, 'bulk_create_test_folders', func)
 
 
+@pytest.fixture
+def mock_clone_git_repo(
+    monkeypatch: pytest.MonkeyPatch,
+    repo_payload: TestRepository,
+):
+    def func(workdir: str, repo_url: str):
+        tests_dir = Path(
+            workdir,
+            repo_url.split('/')[-1].replace('.git', ''),
+            repo_payload.tests_dir,
+        )
+        for i in range(1, 5):
+            Path(tests_dir, f'{repo_payload.tests_prefix}{i}').mkdir(parents=True, exist_ok=True)
+        return 0, '', ''
+
+    monkeypatch.setattr('alma_tests_cacher.cacher.clone_git_repo', func)
+
+
 @pytest.mark.anyio
 @pytest.mark.usefixtures(
     'mock_get_test_repos',
     'mock_bulk_create',
     'mock_bulk_remove',
+    'mock_clone_git_repo'
 )
 async def test_cacher_run(
     cacher: AlmaTestsCacher,


### PR DESCRIPTION
> Also, we don't need to clone repositories in our tests, we can create the needed repositories via pytest fixtures

Isn't it already done with `expected_payload` fixture ?

Resolves: AlmaLinux/alma-tests-cacher#47